### PR TITLE
Rename deprecated method name `update_attributes` to `update`

### DIFF
--- a/lib/two_factor_authentication/models/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/models/two_factor_authenticatable.rb
@@ -101,7 +101,7 @@ module Devise
         def create_direct_otp(options = {})
           # Create a new random OTP and store it in the database
           digits = options[:length] || self.class.direct_otp_length || 6
-          update_attributes(
+          update(
             direct_otp: random_base10(digits),
             direct_otp_sent_at: Time.now.utc
           )
@@ -122,7 +122,7 @@ module Devise
         end
 
         def clear_direct_otp
-          update_attributes(direct_otp: nil, direct_otp_sent_at: nil)
+          update(direct_otp: nil, direct_otp_sent_at: nil)
         end
       end
 

--- a/spec/rails_app/app/models/guest_user.rb
+++ b/spec/rails_app/app/models/guest_user.rb
@@ -7,7 +7,7 @@ class GuestUser
   attr_accessor :direct_otp, :direct_otp_sent_at, :otp_secret_key, :email,
     :second_factor_attempts_count, :totp_timestamp
 
-  def update_attributes(attrs)
+  def update(attrs)
     attrs.each do |key, value|
       send(key.to_s + '=', value)
     end


### PR DESCRIPTION
`ActiveRecord::Base#update_attributes` and `ActiveRecord::Base#update_attributes!` is deprecated at Rails 6.0 and removed at 6.1.

https://railsguides.jp/6_1_release_notes.html#active-record